### PR TITLE
Add numpy recarray format to ps1cone query

### DIFF
--- a/jlu/mast/panstarrs.py
+++ b/jlu/mast/panstarrs.py
@@ -1,22 +1,70 @@
-from astropy.io import ascii
 from astropy.table import Table
-
 import sys
-import re
-import numpy as np
-import pylab
 import json
 import requests
 from urllib.parse import quote as urlencode
-from urllib.request import urlretrieve
-import http.client as httplib 
+import http.client as httplib
+import numpy as np
 
-    
-def ps1cone(ra,dec,radius,table="mean",release="dr1",format="csv",columns=None,
-           baseurl="https://catalogs.mast.stsci.edu/api/v0.1/panstarrs", verbose=False,
-           **kw):
+
+def return_field_dtype(table='mean', release='dr1'):
+    """Creates dictionary with numpy datatypes for each table column
+
+    Parameters
+    ----------
+    table (string): mean, stack, or detection
+    release (string): dr1 or dr2
+    """
+    tab = ps1metadata(table=table, release=release)
+    field_dtype = {}
+    for row in tab:
+        name = row['name']
+        type = row['type']
+        if type in ['char']:
+            type = '|U32'
+        elif type in ['int', 'short', 'long', 'unsignedByte']:
+            type = int
+        elif type in ['float', 'double']:
+            type = float
+        else:
+            raise ValueError(f"Column type {type} missing "
+                             f"from return_field_dtype")
+        field_dtype[name] = type
+    field_dtype['distance'] = float
+    return field_dtype
+
+
+def csvtonumpy(result, table='mean', release='dr1'):
+    """Converts csv results to numpy recarray
+
+    Parameters
+    ----------
+    results (str): result of ps1search function with csv format
+    table (string): mean, stack, or detection
+    release (string): dr1 or dr2
+    """
+    fields = result.split('\n')[0].replace('\r', '').split(',')
+
+    data = []
+    for row in result.split('\n')[1:]:
+        if len(row) == 0:
+            continue
+        d = row.replace('\r', '').split(',')
+        data.append(tuple(d))
+
+    field_dtype = return_field_dtype(table=table, release=release)
+    dtype = np.dtype([(f, field_dtype[f]) for f in fields])
+    result_np = np.array(data, dtype=dtype)
+    return result_np
+
+
+def ps1cone(ra, dec, radius, table="mean", release="dr1", format="csv",
+            columns=None,
+            baseurl="https://catalogs.mast.stsci.edu/api/v0.1/panstarrs",
+            verbose=False,
+            **kw):
     """Do a cone search of the PS1 catalog
-    
+
     Parameters
     ----------
     ra (float): (degrees) J2000 Right Ascension
@@ -24,62 +72,72 @@ def ps1cone(ra,dec,radius,table="mean",release="dr1",format="csv",columns=None,
     radius (float): (degrees) Search radius (<= 0.5 degrees)
     table (string): mean, stack, or detection
     release (string): dr1 or dr2
-    format: csv, votable, json
+    format: csv, votable, json, numpy
     columns: list of column names to include (None means use defaults)
     baseurl: base URL for the request
     verbose: print info about request
     **kw: other parameters (e.g., 'nDetections.min':2)
     """
-    
+
     data = kw.copy()
     data['ra'] = ra
     data['dec'] = dec
     data['radius'] = radius
-    return ps1search(table=table,release=release,format=format,columns=columns,
-                    baseurl=baseurl, verbose=verbose, **data)
+
+    result = ps1search(table=table, release=release, format=format,
+                       columns=columns,
+                       baseurl=baseurl, verbose=verbose, **data)
+
+    return result
 
 
-def ps1search(table="mean",release="dr1",format="csv",columns=None,
-           baseurl="https://catalogs.mast.stsci.edu/api/v0.1/panstarrs", verbose=False,
-           **kw):
+def ps1search(table="mean", release="dr1", format="csv", columns=None,
+              baseurl="https://catalogs.mast.stsci.edu/api/v0.1/panstarrs",
+              verbose=False,
+              **kw):
     """Do a general search of the PS1 catalog (possibly without ra/dec/radius)
-    
+
     Parameters
     ----------
     table (string): mean, stack, or detection
     release (string): dr1 or dr2
-    format: csv, votable, json
+    format: csv, votable, json, numpy
     columns: list of column names to include (None means use defaults)
     baseurl: base URL for the request
     verbose: print info about request
     **kw: other parameters (e.g., 'nDetections.min':2).  Note this is required!
     """
-    
+
     data = kw.copy()
     if not data:
         raise ValueError("You must specify some parameters for search")
-    checklegal(table,release)
-    if format not in ("csv","votable","json"):
+    checklegal(table, release)
+    if format not in ("csv", "votable", "json", "numpy"):
         raise ValueError("Bad value for format")
-    url = "{baseurl}/{release}/{table}.{format}".format(**locals())
+    if format == 'numpy':
+        fmt = "csv"
+    else:
+        fmt = format
+    url = "{baseurl}/{release}/{table}.{fmt}".format(**locals())
     if columns:
         # check that column values are legal
         # create a dictionary to speed this up
         dcols = {}
-        for col in ps1metadata(table,release)['name']:
+        for col in ps1metadata(table, release)['name']:
             dcols[col.lower()] = 1
         badcols = []
         for col in columns:
             if col.lower().strip() not in dcols:
                 badcols.append(col)
         if badcols:
-            raise ValueError('Some columns not found in table: {}'.format(', '.join(badcols)))
+            raise ValueError('Some columns not found in table: {}'.format(
+                ', '.join(badcols)))
         # two different ways to specify a list of column values in the API
         # data['columns'] = columns
         data['columns'] = '[{}]'.format(','.join(columns))
 
-# either get or post works
-#    r = requests.post(url, data=data)
+    # either get or post works
+    #    r = requests.post(url, data=data)
     r = requests.get(url, params=data)
 
     if verbose:
@@ -88,47 +146,54 @@ def ps1search(table="mean",release="dr1",format="csv",columns=None,
     if format == "json":
         return r.json()
     else:
-        return r.text
+        if format == "numpy":
+            return csvtonumpy(r.text, table=table, release=release)
+        else:
+            return r.text
 
 
-def checklegal(table,release):
+def checklegal(table, release):
     """Checks if this combination of table and release is acceptable
-    
+
     Raises a VelueError exception if there is problem
     """
-    
+
     releaselist = ("dr1", "dr2")
-    if release not in ("dr1","dr2"):
-        raise ValueError("Bad value for release (must be one of {})".format(', '.join(releaselist)))
-    if release=="dr1":
+    if release not in ("dr1", "dr2"):
+        raise ValueError("Bad value for release (must be one of {})".format(
+            ', '.join(releaselist)))
+    if release == "dr1":
         tablelist = ("mean", "stack")
     else:
         tablelist = ("mean", "stack", "detection")
     if table not in tablelist:
-        raise ValueError("Bad value for table (for {} must be one of {})".format(release, ", ".join(tablelist)))
+        raise ValueError(
+            "Bad value for table (for {} must be one of {})".format(release,
+                                                                    ", ".join(
+                                                                        tablelist)))
 
 
-def ps1metadata(table="mean",release="dr1",
-           baseurl="https://catalogs.mast.stsci.edu/api/v0.1/panstarrs"):
+def ps1metadata(table="mean", release="dr1",
+                baseurl="https://catalogs.mast.stsci.edu/api/v0.1/panstarrs"):
     """Return metadata for the specified catalog and table
-    
+
     Parameters
     ----------
     table (string): mean, stack, or detection
     release (string): dr1 or dr2
     baseurl: base URL for the request
-    
+
     Returns an astropy table with columns name, type, description
     """
-    
-    checklegal(table,release)
+
+    checklegal(table, release)
     url = "{baseurl}/{release}/{table}/metadata".format(**locals())
     r = requests.get(url)
     r.raise_for_status()
     v = r.json()
     # convert to astropy table
-    tab = Table(rows=[(x['name'],x['type'],x['description']) for x in v],
-               names=('name','type','description'))
+    tab = Table(rows=[(x['name'], x['type'], x['description']) for x in v],
+                names=('name', 'type', 'description'))
     return tab
 
 
@@ -141,26 +206,26 @@ def mastQuery(request):
 
     Returns head,content where head is the response HTTP headers, and content is the returned data
     """
-    
-    server='mast.stsci.edu'
 
-    # Grab Python Version 
+    server = 'mast.stsci.edu'
+
+    # Grab Python Version
     version = ".".join(map(str, sys.version_info[:3]))
 
     # Create Http Header Variables
     headers = {"Content-type": "application/x-www-form-urlencoded",
                "Accept": "text/plain",
-               "User-agent":"python-requests/"+version}
+               "User-agent": "python-requests/" + version}
 
     # Encoding the request as a json string
     requestString = json.dumps(request)
     requestString = urlencode(requestString)
-    
+
     # opening the https connection
     conn = httplib.HTTPSConnection(server)
 
     # Making the query
-    conn.request("POST", "/api/v0/invoke", "request="+requestString, headers)
+    conn.request("POST", "/api/v0/invoke", "request=" + requestString, headers)
 
     # Getting the response
     resp = conn.getresponse()
@@ -170,26 +235,26 @@ def mastQuery(request):
     # Close the https connection
     conn.close()
 
-    return head,content
+    return head, content
 
 
 def resolve(name):
     """Get the RA and Dec for an object using the MAST name resolver
-    
+
     Parameters
     ----------
     name (str): Name of object
 
     Returns RA, Dec tuple with position"""
 
-    resolverRequest = {'service':'Mast.Name.Lookup',
-                       'params':{'input':name,
-                                 'format':'json'
-                                },
-                      }
-    headers,resolvedObjectString = mastQuery(resolverRequest)
+    resolverRequest = {'service': 'Mast.Name.Lookup',
+                       'params': {'input': name,
+                                  'format': 'json'
+                                  },
+                       }
+    headers, resolvedObjectString = mastQuery(resolverRequest)
     resolvedObject = json.loads(resolvedObjectString)
-    # The resolver returns a variety of information about the resolved object, 
+    # The resolver returns a variety of information about the resolved object,
     # however for our purposes all we need are the RA and Dec
     try:
         objRa = resolvedObject['resolvedCoordinate'][0]['ra']
@@ -197,4 +262,3 @@ def resolve(name):
     except IndexError as e:
         raise ValueError("Unknown object '{}'".format(name))
     return (objRa, objDec)
-

--- a/jlu/mast/panstarrs.py
+++ b/jlu/mast/panstarrs.py
@@ -59,7 +59,7 @@ def csvtonumpy(result, table='mean', release='dr1'):
 
 
 def ps1cone(ra, dec, radius, table="mean", release="dr1", format="csv",
-            columns=None,
+            columns=None, pagesize=0,
             baseurl="https://catalogs.mast.stsci.edu/api/v0.1/panstarrs",
             verbose=False,
             **kw):
@@ -74,6 +74,7 @@ def ps1cone(ra, dec, radius, table="mean", release="dr1", format="csv",
     release (string): dr1 or dr2
     format: csv, votable, json, numpy
     columns: list of column names to include (None means use defaults)
+    pagesize: maximum number of records in response (0 means no limit)
     baseurl: base URL for the request
     verbose: print info about request
     **kw: other parameters (e.g., 'nDetections.min':2)
@@ -85,13 +86,14 @@ def ps1cone(ra, dec, radius, table="mean", release="dr1", format="csv",
     data['radius'] = radius
 
     result = ps1search(table=table, release=release, format=format,
-                       columns=columns,
+                       columns=columns, pagesize=pagesize,
                        baseurl=baseurl, verbose=verbose, **data)
 
     return result
 
 
-def ps1search(table="mean", release="dr1", format="csv", columns=None,
+def ps1search(table="mean", release="dr1", format="csv", 
+              columns=None, pagesize=0,
               baseurl="https://catalogs.mast.stsci.edu/api/v0.1/panstarrs",
               verbose=False,
               **kw):
@@ -103,6 +105,7 @@ def ps1search(table="mean", release="dr1", format="csv", columns=None,
     release (string): dr1 or dr2
     format: csv, votable, json, numpy
     columns: list of column names to include (None means use defaults)
+    pagesize: maximum number of records in response (0 means no limit)
     baseurl: base URL for the request
     verbose: print info about request
     **kw: other parameters (e.g., 'nDetections.min':2).  Note this is required!
@@ -135,7 +138,9 @@ def ps1search(table="mean", release="dr1", format="csv", columns=None,
         # two different ways to specify a list of column values in the API
         # data['columns'] = columns
         data['columns'] = '[{}]'.format(','.join(columns))
-
+    
+    data['pagesize'] = int(pagesize)
+        
     # either get or post works
     #    r = requests.post(url, data=data)
     r = requests.get(url, params=data)


### PR DESCRIPTION
The current formats for ps1cone are csv, votable, and json. This update allows the user to receive their results as a numpy recarray. The query requests a csv from the server and then converts that csv result into a recarray using `csvtonumpy`. This function converts the csv results by running a `ps1metadata` query for the same table and release, and then using the values that function returns along with the csv results the header row to create the dtype for the recarray. The rest of the csv results are turned into the data of the recarray.

This commit also removes extraneous imports, and applies some cosmetic reformatting to the code with spaces and such.

The second commit gives explicit control over the maximum number of entries returned by ps1cone.